### PR TITLE
Only transform if it is not already in the SSH format

### DIFF
--- a/Packages/com.coffee.upm-git-extension/Editor/Coffee.UpmGitExtension/UI/InstallPackageWindow.cs
+++ b/Packages/com.coffee.upm-git-extension/Editor/Coffee.UpmGitExtension/UI/InstallPackageWindow.cs
@@ -13,6 +13,8 @@ using UnityEngine.Experimental.UIElements;
 
 namespace Coffee.UpmGitExtension
 {
+    using System;
+
     internal class InstallPackageWindow : VisualElement
     {
         //################################
@@ -187,8 +189,13 @@ namespace Coffee.UpmGitExtension
 
         public static string GetRepoUrl(string url)
         {
-            Match m = Regex.Match(url, "(git@[^:]+):(.*)");
-            string ret = m.Success ? string.Format("ssh://{0}/{1}", m.Groups[1].Value, m.Groups[2].Value) : url;
+            string ret = url;
+
+            if (!url.StartsWith("ssh://", StringComparison.InvariantCultureIgnoreCase))
+            {
+                Match m = Regex.Match(url, "(git@[^:]+):(.*)");
+                ret = m.Success ? string.Format("ssh://{0}/{1}", m.Groups[1].Value, m.Groups[2].Value) : url;
+            }
 #if UNITY_2019_1_OR_NEWER
             return ret.EndsWith(".git") ? ret : "git+" + ret;
 #else


### PR DESCRIPTION
Currently all URLs are transformed even if they're in the correct format, this PR fixes that.

Fixes #47 