### PR TITLE
Fixed the bug where private repositories couldn't be cloned

### DIFF
--- a/Packages/com.coffee.upm-git-extension/Editor/Coffee.UpmGitExtension/Utils.cs
+++ b/Packages/com.coffee.upm-git-extension/Editor/Coffee.UpmGitExtension/Utils.cs
@@ -133,7 +133,7 @@ namespace Coffee.UpmGitExtension
                 dependencies?.Add(packageName, repoUrl + "#" + refName);
 
                 // Unlock git revision.
-                var locks = manifest["lock"] as Dictionary<string, object>;
+                var locks = manifest.TryGetValue("lock", out object lockValue) ? lockValue as Dictionary<string, object> : null;
                 if (locks != null && locks.ContainsKey(packageName))
                     locks.Remove(packageName);
             });


### PR DESCRIPTION
#89 

There was  bug in the Utils.cs class that would throw an exception on private repos and cause a clone to fail.  It appears that logic was put in place for if the lock is null.  However, it was accessed using an indexer requiring the lock to not be null.  Using ``TryGetValue`` allows for the lock to be null.